### PR TITLE
documentのonload以降に生成されるtextareaへの対応

### DIFF
--- a/src/js/lttm.coffee
+++ b/src/js/lttm.coffee
@@ -103,14 +103,10 @@ atwhoOptions =
           )
           callback images
 
-$ ->
-  $("textarea").atwho(atwhoOptions)
-
-# for line comment on github
-$(document).on 'click', '.add-line-comment', (ev) ->
-  setTimeout ->
-    $("textarea").atwho(atwhoOptions)
-  , 1000
+$(document).on 'focusin', (ev) ->
+  $this = $ ev.target
+  return unless $this.is 'textarea'
+  $this.atwho atwhoOptions
 
 $(document).on 'keyup.atwhoInner', (ev) ->
   setTimeout ->


### PR DESCRIPTION
githubなどの`pushState`で遷移するページだと、`document`の`onload`以降で生成された`textarea`にてLTTMできませんでした。
(リロードすると使えたのですが、遷移後に表示された`textarea`だと使えませんでした)

---

ですので`focusin`のタイミングで`atwho`を実行することで、より汎用的な形で`atwho`を適用できるようにしました。
(そのため`.add-line-comment`を`live`な感じでバインドする必要がなくなりました)

atwhoのコードを見る限り、重複してatwhoを実行しても良さそうに見えたので、特にフラグの管理などはしていません。

---

よろしくお願いいたします。
