### PR TITLE
Improve z-index for GitHub review popup

### DIFF
--- a/src/css/lttm.scss
+++ b/src/css/lttm.scss
@@ -3,6 +3,7 @@
   max-width: 790px;
   max-height: 400px;
   overflow: scroll;
+  z-index: 101;
 }
 
 .atwho-view ul li.lttm {


### PR DESCRIPTION
GitHubのレビュー機能のポップアップの中だと下に重なってしまっていたので、z-indexを上げました。

GitHubのレビューポップアップが100だったので101にしてます。ほとんどの場合最上位に表示されてほしいはずなのでもっとあげちゃってもいいかもしれませんが、ひとまずこれでポップアップ内でも使えます！

## before
![pasted image at 2016_12_02 10_36](https://cloud.githubusercontent.com/assets/6822923/20820687/6a3d57f8-b880-11e6-88b3-5abe8a2c7707.png)

## after
![2016-12-02 11 11 14](https://cloud.githubusercontent.com/assets/6822923/20820695/721aa192-b880-11e6-934e-347601fde33e.png)
