### PR TITLE
Fix release task; prevent image corruption

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ gulp.task("clean", function () {
 });
 
 gulp.task("zip", function () {
-  return gulp.src("build/**/*.*").pipe(zip("build.zip")).pipe(gulp.dest("./"));
+  return gulp.src("build/**/*.*", { encoding: false }).pipe(zip("build.zip")).pipe(gulp.dest("./"));
 });
 
 gulp.task(


### PR DESCRIPTION
- #91 

`npm run release` で画像が壊れるのを修正

> https://github.com/gulpjs/gulp/issues/2777#issuecomment-2036776560